### PR TITLE
remove the slave deployment when `cluster_enabled` is false

### DIFF
--- a/redis-slave-deployment.tf
+++ b/redis-slave-deployment.tf
@@ -1,4 +1,7 @@
 resource kubernetes_deployment redis_slave {
+
+  count = var.cluster_enabled ? 1 : 0
+
   metadata {
     name      = "${local.fullname}-slave"
     namespace = var.kubernetes_namespace

--- a/redis-slave-svc.tf
+++ b/redis-slave-svc.tf
@@ -1,4 +1,7 @@
 resource kubernetes_service redis_slave {
+
+  count = var.cluster_enabled ? 1 : 0
+
   metadata {
     name      = "${local.fullname}-slave"
     namespace = var.kubernetes_namespace


### PR DESCRIPTION
According to the docs, we should only deploy a redis master when `cluster_enabled` is `false`. However we still deploy a slave even when the cluster is disabled.

This PR removes the `redis_slave` deployment and the `redis_slave` service by setting their count to 0, when `cluster_enabled` is false.